### PR TITLE
Confirm article summary lengths before publishing summaries.

### DIFF
--- a/utils/publisher.py
+++ b/utils/publisher.py
@@ -285,6 +285,7 @@ if __name__ == "__main__":
     if debug:
         deploy_language("Arabic")
         deploy_language("English")
+        deploy_language("Hungarian")
     else:
         with open('config/languages.json', 'r') as file:
             lang_configs = json.load(file)


### PR DESCRIPTION
While checking TranslateTribune this morning we've noticed some unacceptably long article summaries for articles routed to Gemini Flash.

![image](https://github.com/Medusa-ML/TranslateTribune/assets/272026/fdd8114f-def4-4deb-ba99-9f4497626725)

I suspect this is caused by submitting a long prompt to Gemini Flash, and we're working on prompt optimization tools for ND users which hopefully remedy these issues. In the meantime, we've submitted a fix which falls back to Haiku for abnormally long summaries. Happy to make any changes you all would like to see.